### PR TITLE
refactor: SwaggerParameterMapper のリファクタリング

### DIFF
--- a/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
@@ -7,8 +7,9 @@ import scala.reflect.runtime.universe._
 
 import com.fasterxml.jackson.databind.{BeanDescription, ObjectMapper}
 import com.github.takezoe.scaladoc.Scaladoc
-import com.iheart.playSwagger.Domain.{Definition, GenSwaggerParameter, SwaggerParameter}
+import com.iheart.playSwagger.Domain.Definition
 import com.iheart.playSwagger.domain.CustomTypeMapping
+import com.iheart.playSwagger.domain.parameter.{GenSwaggerParameter, SwaggerParameter}
 import com.iheart.playSwagger.generator.SwaggerParameterMapper.mapParam
 import net.steppschuh.markdowngenerator.MarkdownElement
 import net.steppschuh.markdowngenerator.link.Link
@@ -120,7 +121,7 @@ final case class DefinitionGenerator(
       )
   }
 
-  private def definitionForPOJO(tpe: Type): Seq[Domain.SwaggerParameter] = {
+  private def definitionForPOJO(tpe: Type): Seq[SwaggerParameter] = {
     val m = runtimeMirror(cl)
     val clazz = m.runtimeClass(tpe.typeSymbol.asClass)
     val `type` = _mapper.constructType(clazz)

--- a/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
@@ -8,7 +8,7 @@ import scala.reflect.runtime.universe._
 import com.fasterxml.jackson.databind.{BeanDescription, ObjectMapper}
 import com.github.takezoe.scaladoc.Scaladoc
 import com.iheart.playSwagger.Domain.{CustomMappings, Definition, GenSwaggerParameter, SwaggerParameter}
-import com.iheart.playSwagger.SwaggerParameterMapper.mapParam
+import com.iheart.playSwagger.generator.SwaggerParameterMapper.mapParam
 import net.steppschuh.markdowngenerator.MarkdownElement
 import net.steppschuh.markdowngenerator.link.Link
 import net.steppschuh.markdowngenerator.table.Table

--- a/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
@@ -7,7 +7,8 @@ import scala.reflect.runtime.universe._
 
 import com.fasterxml.jackson.databind.{BeanDescription, ObjectMapper}
 import com.github.takezoe.scaladoc.Scaladoc
-import com.iheart.playSwagger.Domain.{CustomMappings, Definition, GenSwaggerParameter, SwaggerParameter}
+import com.iheart.playSwagger.Domain.{Definition, GenSwaggerParameter, SwaggerParameter}
+import com.iheart.playSwagger.domain.CustomTypeMapping
 import com.iheart.playSwagger.generator.SwaggerParameterMapper.mapParam
 import net.steppschuh.markdowngenerator.MarkdownElement
 import net.steppschuh.markdowngenerator.link.Link
@@ -19,7 +20,7 @@ import play.routes.compiler.Parameter
 
 final case class DefinitionGenerator(
     modelQualifier: DomainModelQualifier = PrefixDomainModelQualifier(),
-    mappings: CustomMappings = Nil,
+    mappings: Seq[CustomTypeMapping] = Nil,
     swaggerPlayJava: Boolean = false,
     _mapper: ObjectMapper = new ObjectMapper(),
     namingStrategy: NamingStrategy = NamingStrategy.None,
@@ -186,7 +187,7 @@ final case class DefinitionGenerator(
 object DefinitionGenerator {
   def apply(
       domainNameSpace: String,
-      customParameterTypeMappings: CustomMappings,
+      customParameterTypeMappings: Seq[CustomTypeMapping],
       swaggerPlayJava: Boolean,
       namingStrategy: NamingStrategy
   )(implicit cl: ClassLoader): DefinitionGenerator =
@@ -199,7 +200,7 @@ object DefinitionGenerator {
 
   def apply(
       domainNameSpace: String,
-      customParameterTypeMappings: CustomMappings,
+      customParameterTypeMappings: Seq[CustomTypeMapping],
       namingStrategy: NamingStrategy,
       embedScaladoc: Boolean
   )(implicit cl: ClassLoader): DefinitionGenerator =

--- a/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
@@ -8,9 +8,8 @@ import scala.reflect.runtime.universe._
 import com.fasterxml.jackson.databind.{BeanDescription, ObjectMapper}
 import com.github.takezoe.scaladoc.Scaladoc
 import com.iheart.playSwagger.Domain.Definition
-import com.iheart.playSwagger.domain.CustomTypeMapping
 import com.iheart.playSwagger.domain.parameter.{GenSwaggerParameter, SwaggerParameter}
-import com.iheart.playSwagger.generator.SwaggerParameterMapper.mapParam
+import com.iheart.playSwagger.generator.SwaggerParameterMapper
 import net.steppschuh.markdowngenerator.MarkdownElement
 import net.steppschuh.markdowngenerator.link.Link
 import net.steppschuh.markdowngenerator.table.Table
@@ -20,8 +19,7 @@ import net.steppschuh.markdowngenerator.text.heading.Heading
 import play.routes.compiler.Parameter
 
 final case class DefinitionGenerator(
-    modelQualifier: DomainModelQualifier = PrefixDomainModelQualifier(),
-    mappings: Seq[CustomTypeMapping] = Nil,
+    mapper: SwaggerParameterMapper,
     swaggerPlayJava: Boolean = false,
     _mapper: ObjectMapper = new ObjectMapper(),
     namingStrategy: NamingStrategy = NamingStrategy.None,
@@ -111,7 +109,7 @@ final case class DefinitionGenerator(
           val typeName = parametricType.resolve(rawTypeName)
           // passing None for 'fixed' and 'default' here, since we're not dealing with route parameters
           val param = Parameter(name, typeName, None, None)
-          mapParam(param, modelQualifier, mappings, paramDescriptions.get(field.name.decodedName.toString))
+          mapper.mapParam(param, paramDescriptions.get(field.name.decodedName.toString))
         }
       }
 
@@ -144,7 +142,7 @@ final case class DefinitionGenerator(
         generalTypeName
       }
       val param = Parameter(name, typeName, None, None)
-      mapParam(param, modelQualifier, mappings)
+      mapper.mapParam(param, None)
     }
   }
 
@@ -168,9 +166,9 @@ final case class DefinitionGenerator(
         case None =>
           val thisDef = definition(defName)
           val refNames: Seq[String] = for {
-            p ← thisDef.properties.collect(genSwaggerParameter)
-            className ← findRefTypes(p)
-            if modelQualifier.isModel(className)
+            p <- thisDef.properties.collect(genSwaggerParameter)
+            className <- findRefTypes(p)
+            if mapper.isReference(className)
           } yield className
 
           refNames.foldLeft(thisDef :: memo) { (foundDefs, refName) =>
@@ -187,27 +185,23 @@ final case class DefinitionGenerator(
 
 object DefinitionGenerator {
   def apply(
-      domainNameSpace: String,
-      customParameterTypeMappings: Seq[CustomTypeMapping],
+      mapper: SwaggerParameterMapper,
       swaggerPlayJava: Boolean,
       namingStrategy: NamingStrategy
   )(implicit cl: ClassLoader): DefinitionGenerator =
-    DefinitionGenerator(
-      PrefixDomainModelQualifier(domainNameSpace),
-      customParameterTypeMappings,
+    new DefinitionGenerator(
+      mapper,
       swaggerPlayJava,
       namingStrategy = namingStrategy
     )
 
   def apply(
-      domainNameSpace: String,
-      customParameterTypeMappings: Seq[CustomTypeMapping],
+      mapper: SwaggerParameterMapper,
       namingStrategy: NamingStrategy,
       embedScaladoc: Boolean
   )(implicit cl: ClassLoader): DefinitionGenerator =
-    DefinitionGenerator(
-      PrefixDomainModelQualifier(domainNameSpace),
-      customParameterTypeMappings,
+    new DefinitionGenerator(
+      mapper,
       namingStrategy = namingStrategy,
       embedScaladoc = embedScaladoc
     )

--- a/core/src/main/scala/com/iheart/playSwagger/Domain.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/Domain.scala
@@ -1,6 +1,6 @@
 package com.iheart.playSwagger
 
-import play.api.libs.json.{JsObject, JsValue}
+import com.iheart.playSwagger.domain.parameter.SwaggerParameter
 
 object Domain {
   type Path = String
@@ -11,45 +11,4 @@ object Domain {
       properties: Seq[SwaggerParameter],
       description: Option[String] = None
   )
-
-  sealed trait SwaggerParameter {
-    def name: String
-    def required: Boolean
-    def nullable: Option[Boolean]
-    def default: Option[JsValue]
-    def description: Option[String]
-
-    def update(required: Boolean, nullable: Boolean, default: Option[JsValue]): SwaggerParameter
-  }
-
-  final case class GenSwaggerParameter(
-      name: String,
-      referenceType: Option[String] = None,
-      `type`: Option[String] = None,
-      format: Option[String] = None,
-      required: Boolean = true,
-      nullable: Option[Boolean] = None,
-      default: Option[JsValue] = None,
-      example: Option[JsValue] = None,
-      items: Option[SwaggerParameter] = None,
-      enum: Option[Seq[String]] = None,
-      description: Option[String] = None
-  ) extends SwaggerParameter {
-    def update(_required: Boolean, _nullable: Boolean, _default: Option[JsValue]): GenSwaggerParameter =
-      copy(required = _required, nullable = Some(_nullable), default = _default)
-  }
-
-  final case class CustomSwaggerParameter(
-      name: String,
-      specAsParameter: List[JsObject],
-      specAsProperty: Option[JsObject],
-      required: Boolean = true,
-      nullable: Option[Boolean] = None,
-      default: Option[JsValue] = None,
-      description: Option[String] = None
-  ) extends SwaggerParameter {
-    def update(_required: Boolean, _nullable: Boolean, _default: Option[JsValue]): CustomSwaggerParameter =
-      copy(required = _required, nullable = Some(_nullable), default = _default)
-  }
-
 }

--- a/core/src/main/scala/com/iheart/playSwagger/Domain.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/Domain.scala
@@ -1,6 +1,6 @@
 package com.iheart.playSwagger
 
-import play.api.libs.json.{JsObject, JsPath, JsValue, Reads}
+import play.api.libs.json.{JsObject, JsValue}
 
 object Domain {
   type Path = String
@@ -52,22 +52,4 @@ object Domain {
       copy(required = _required, nullable = Some(_nullable), default = _default)
   }
 
-  type CustomMappings = List[CustomTypeMapping]
-
-  case class CustomTypeMapping(
-      `type`: String,
-      specAsParameter: List[JsObject] = Nil,
-      specAsProperty: Option[JsObject] = None,
-      required: Boolean = true
-  )
-
-  object CustomTypeMapping {
-    import play.api.libs.functional.syntax._
-    implicit val csmFormat: Reads[CustomTypeMapping] = (
-      (JsPath \ 'type).read[String] and
-        (JsPath \ 'specAsParameter).read[List[JsObject]] and
-        (JsPath \ 'specAsProperty).readNullable[JsObject] and
-        ((JsPath \ 'required).read[Boolean] orElse Reads.pure(true))
-    )(CustomTypeMapping.apply _)
-  }
 }

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.iheart.playSwagger.Domain._
 import com.iheart.playSwagger.OutputTransformer.SimpleOutputTransformer
 import com.iheart.playSwagger.ResourceReader.read
-import com.iheart.playSwagger.SwaggerParameterMapper.mapParam
+import com.iheart.playSwagger.generator.SwaggerParameterMapper.mapParam
 import org.yaml.snakeyaml.Yaml
 import play.api.libs.json.JsValue.jsValueToJsLookup
 import play.api.libs.json._

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecRunner.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecRunner.scala
@@ -4,6 +4,7 @@ import java.nio.file.{Files, Paths, StandardOpenOption}
 
 import scala.util.{Failure, Success, Try}
 
+import com.iheart.playSwagger.generator.SwaggerSpecGenerator
 import play.api.libs.json.{JsValue, Json}
 
 object SwaggerSpecRunner extends App {

--- a/core/src/main/scala/com/iheart/playSwagger/domain/CustomTypeMapping.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/domain/CustomTypeMapping.scala
@@ -1,0 +1,20 @@
+package com.iheart.playSwagger.domain
+
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.{JsObject, JsPath, Reads}
+
+case class CustomTypeMapping(
+    `type`: String,
+    specAsParameter: List[JsObject] = Nil,
+    specAsProperty: Option[JsObject] = None,
+    required: Boolean = true
+)
+
+object CustomTypeMapping {
+  implicit val reads: Reads[CustomTypeMapping] = (
+    (JsPath \ "type").read[String] and
+      (JsPath \ "specAsParameter").read[List[JsObject]] and
+      (JsPath \ "specAsProperty").readNullable[JsObject] and
+      ((JsPath \ "required").read[Boolean].orElse(Reads.pure(true)))
+  )(CustomTypeMapping.apply _)
+}

--- a/core/src/main/scala/com/iheart/playSwagger/domain/parameter/CustomSwaggerParameter.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/domain/parameter/CustomSwaggerParameter.scala
@@ -1,0 +1,16 @@
+package com.iheart.playSwagger.domain.parameter
+
+import play.api.libs.json.{JsObject, JsValue}
+
+final case class CustomSwaggerParameter(
+    override val name: String,
+    specAsParameter: List[JsObject],
+    specAsProperty: Option[JsObject],
+    override val required: Boolean = true,
+    override val nullable: Option[Boolean] = None,
+    override val default: Option[JsValue] = None,
+    override val description: Option[String] = None
+) extends SwaggerParameter {
+  def update(_required: Boolean, _nullable: Boolean, _default: Option[JsValue]): CustomSwaggerParameter =
+    copy(required = _required, nullable = Some(_nullable), default = _default)
+}

--- a/core/src/main/scala/com/iheart/playSwagger/domain/parameter/GenSwaggerParameter.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/domain/parameter/GenSwaggerParameter.scala
@@ -1,0 +1,40 @@
+package com.iheart.playSwagger.domain.parameter
+
+import play.api.libs.json.JsValue
+
+final case class GenSwaggerParameter private (
+    override val name: String,
+    override val required: Boolean,
+    override val description: Option[String] = None,
+    referenceType: Option[String] = None,
+    `type`: Option[String] = None,
+    format: Option[String] = None,
+    override val nullable: Option[Boolean] = None,
+    override val default: Option[JsValue] = None,
+    example: Option[JsValue] = None,
+    items: Option[SwaggerParameter] = None,
+    enum: Option[Seq[String]] = None
+) extends SwaggerParameter {
+  override def update(_required: Boolean, _nullable: Boolean, _default: Option[JsValue]): GenSwaggerParameter =
+    copy(required = _required, nullable = Some(_nullable), default = _default)
+}
+
+object GenSwaggerParameter {
+  def apply(
+      `type`: String,
+      format: Option[String],
+      enum: Option[Seq[String]]
+  )(implicit name: String, default: Option[JsValue], description: Option[String]): GenSwaggerParameter =
+    new GenSwaggerParameter(
+      name,
+      `type` = Some(`type`),
+      format = format,
+      required = default.isEmpty,
+      default = default,
+      enum = enum,
+      description = description
+    )
+
+  def apply(name: String, `type`: String): GenSwaggerParameter =
+    new GenSwaggerParameter(name, required = true, `type` = Some(`type`))
+}

--- a/core/src/main/scala/com/iheart/playSwagger/domain/parameter/SwaggerParameter.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/domain/parameter/SwaggerParameter.scala
@@ -1,0 +1,18 @@
+package com.iheart.playSwagger.domain.parameter
+
+import play.api.libs.json.JsValue
+
+/** [[https://swagger.io/specification/?sbsearch=-schema%20-object#parameter-object Parameter Object]] */
+trait SwaggerParameter {
+  def name: String
+
+  def required: Boolean
+
+  def nullable: Option[Boolean]
+
+  def default: Option[JsValue]
+
+  def description: Option[String]
+
+  def update(required: Boolean, nullable: Boolean, default: Option[JsValue]): SwaggerParameter
+}

--- a/core/src/main/scala/com/iheart/playSwagger/domain/parameter/SwaggerParameterWriter.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/domain/parameter/SwaggerParameterWriter.scala
@@ -1,0 +1,90 @@
+package com.iheart.playSwagger.domain.parameter
+
+import play.api.libs.functional.syntax.{toFunctionalBuilderOps, unlift}
+import play.api.libs.json._
+class SwaggerParameterWriter(swaggerV3: Boolean) {
+
+  private val nullableName: String = if (swaggerV3) "nullable" else "x-nullable"
+
+  private val under: JsPath = if (swaggerV3) __ \ "schema" else __
+
+  val referencePrefix: String = if (swaggerV3) "#/components/schemas/" else "#/definitions/"
+
+  lazy val propWrites: Writes[SwaggerParameter] = Writes {
+    case g: GenSwaggerParameter => genPropWrites.writes(g)
+    case c: CustomSwaggerParameter => customPropWrites.writes(c)
+  }
+
+  private val customPropWrites: Writes[CustomSwaggerParameter] = Writes { cwp =>
+    (__ \ "default").writeNullable[JsValue].writes(cwp.default) ++
+      (__ \ nullableName).writeNullable[Boolean].writes(cwp.nullable) ++
+      (cwp.specAsProperty orElse cwp.specAsParameter.headOption).getOrElse(Json.obj())
+  }
+
+  def customParamWrites(csp: CustomSwaggerParameter): List[JsObject] = {
+    csp.specAsParameter match {
+      case head :: tail =>
+        val w = (
+          (__ \ 'name).write[String] ~
+            (__ \ 'required).write[Boolean] ~
+            (under \ nullableName).writeNullable[Boolean] ~
+            (under \ 'default).writeNullable[JsValue]
+        )((c: CustomSwaggerParameter) => (c.name, c.required, c.nullable, c.default))
+        (w.writes(csp) ++ withPrefix(head)) :: tail
+      // 要素が1つの場合は `elem :: Nil` になるので残りは `Nil` のみ
+      case Nil => Nil
+    }
+  }
+
+  private def withPrefix(input: JsObject): JsObject = {
+    if (swaggerV3) Json.obj("schema" -> input) else input
+  }
+
+  private val refWrite: Writes[String] = Writes { (refType: String) =>
+    Json.obj("$ref" -> JsString(referencePrefix + refType))
+  }
+
+  val genParamWrites: OWrites[GenSwaggerParameter] = {
+    (
+      (__ \ "name").write[String] ~
+        (__ \ "required").write[Boolean] ~
+        (__ \ "description").writeNullable[String] ~
+        // referenceType は `schema: $ref: ` という表記になる
+        (__ \ "schema").writeNullable[String](refWrite) ~
+        (under \ "type").writeNullable[String] ~
+        (under \ "format").writeNullable[String] ~
+        (under \ nullableName).writeNullable[Boolean] ~
+        (under \ "default").writeNullable[JsValue] ~
+        (under \ "example").writeNullable[JsValue] ~
+        (under \ "items").writeNullable[SwaggerParameter](propWrites) ~
+        (under \ "enum").writeNullable[Seq[String]]
+    )(unlift(GenSwaggerParameter.unapply))
+  }
+
+  private val genPropWrites: Writes[GenSwaggerParameter] = {
+
+    val writesBuilder = (__ \ "type").writeNullable[String] ~
+      (__ \ "format").writeNullable[String] ~
+      (__ \ nullableName).writeNullable[Boolean] ~
+      (__ \ "default").writeNullable[JsValue] ~
+      (__ \ "example").writeNullable[JsValue] ~
+      (__ \ "$ref").writeNullable[String] ~
+      (__ \ "items").lazyWriteNullable[SwaggerParameter](propWrites) ~
+      (__ \ "enum").writeNullable[Seq[String]] ~
+      (__ \ "description").writeNullable[String]
+
+    writesBuilder { p =>
+      Tuple9(
+        p.`type`,
+        p.format,
+        p.nullable,
+        p.default,
+        p.example,
+        p.referenceType.map(referencePrefix + _),
+        p.items,
+        p.enum,
+        p.description
+      )
+    }
+  }
+}

--- a/core/src/main/scala/com/iheart/playSwagger/exception/RoutesParseException.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/exception/RoutesParseException.scala
@@ -1,0 +1,26 @@
+package com.iheart.playSwagger.exception
+
+import com.iheart.playSwagger.exception.RoutesParseException.RoutesParseErrorDetail
+
+class RoutesParseException(errors: Seq[RoutesParseErrorDetail]) extends RuntimeException(
+      errors.map { error =>
+        val caret = error.column.map(c => (" " * (c - 1)) + "^").getOrElse("")
+        // line Number がある場合は ":" と共に表記する
+        val lineNumberText = error.lineNumber.fold("")(n => f":$n")
+        s"""|Error parsing routes file: ${error.sourceFileName}$lineNumberText ${error.message}
+        |${error.content.fold("")(_)}
+        |$caret
+        |""".stripMargin
+      }.mkString("\n")
+    )
+
+object RoutesParseException {
+  case class RoutesParseErrorTargetLine()
+  case class RoutesParseErrorDetail(
+      sourceFileName: String,
+      message: String,
+      content: Option[String] = None,
+      lineNumber: Option[Int] = None,
+      column: Option[Int] = None
+  )
+}

--- a/core/src/main/scala/com/iheart/playSwagger/generator/ResourceReader.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/generator/ResourceReader.scala
@@ -1,4 +1,4 @@
-package com.iheart.playSwagger
+package com.iheart.playSwagger.generator
 
 import java.io.{IOException, InputStream}
 

--- a/core/src/main/scala/com/iheart/playSwagger/generator/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/generator/SwaggerParameterMapper.scala
@@ -4,7 +4,8 @@ import scala.reflect.runtime.universe
 import scala.util.Try
 import scala.util.matching.Regex
 
-import com.iheart.playSwagger.Domain.{CustomMappings, CustomSwaggerParameter, GenSwaggerParameter, SwaggerParameter}
+import com.iheart.playSwagger.Domain.{CustomSwaggerParameter, GenSwaggerParameter, SwaggerParameter}
+import com.iheart.playSwagger.domain.CustomTypeMapping
 import com.iheart.playSwagger.{DomainModelQualifier, PrefixDomainModelQualifier}
 import play.api.libs.json._
 import play.routes.compiler.Parameter
@@ -16,7 +17,7 @@ object SwaggerParameterMapper {
   def mapParam(
       parameter: Parameter,
       modelQualifier: DomainModelQualifier = PrefixDomainModelQualifier(),
-      customMappings: CustomMappings = Nil,
+      customMappings: Seq[CustomTypeMapping] = Nil,
       description: Option[String] = None
   )(implicit cl: ClassLoader): SwaggerParameter = {
 

--- a/core/src/main/scala/com/iheart/playSwagger/generator/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/generator/SwaggerParameterMapper.scala
@@ -1,10 +1,11 @@
-package com.iheart.playSwagger
+package com.iheart.playSwagger.generator
 
 import scala.reflect.runtime.universe
 import scala.util.Try
 import scala.util.matching.Regex
 
 import com.iheart.playSwagger.Domain.{CustomMappings, CustomSwaggerParameter, GenSwaggerParameter, SwaggerParameter}
+import com.iheart.playSwagger.{DomainModelQualifier, PrefixDomainModelQualifier}
 import play.api.libs.json._
 import play.routes.compiler.Parameter
 

--- a/core/src/main/scala/com/iheart/playSwagger/generator/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/generator/SwaggerParameterMapper.scala
@@ -4,8 +4,8 @@ import scala.reflect.runtime.universe
 import scala.util.Try
 import scala.util.matching.Regex
 
-import com.iheart.playSwagger.Domain.{CustomSwaggerParameter, GenSwaggerParameter, SwaggerParameter}
 import com.iheart.playSwagger.domain.CustomTypeMapping
+import com.iheart.playSwagger.domain.parameter.{CustomSwaggerParameter, GenSwaggerParameter, SwaggerParameter}
 import com.iheart.playSwagger.{DomainModelQualifier, PrefixDomainModelQualifier}
 import play.api.libs.json._
 import play.routes.compiler.Parameter
@@ -83,7 +83,7 @@ object SwaggerParameterMapper {
     def isReference(tpeName: String = typeName): Boolean = modelQualifier.isModel(tpeName)
 
     def referenceParam(referenceType: String) =
-      GenSwaggerParameter(parameter.name, referenceType = Some(referenceType))
+      GenSwaggerParameter(parameter.name, required = true, referenceType = Some(referenceType))
 
     def optionalParam(optionalTpe: String) = {
       val asRequired = mapParam(

--- a/core/src/main/scala/com/iheart/playSwagger/generator/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/generator/SwaggerSpecGenerator.scala
@@ -9,6 +9,7 @@ import scala.util.{Failure, Success, Try}
 import com.iheart.playSwagger.Domain._
 import com.iheart.playSwagger.OutputTransformer.SimpleOutputTransformer
 import com.iheart.playSwagger._
+import com.iheart.playSwagger.domain.CustomTypeMapping
 import com.iheart.playSwagger.generator.ResourceReader.read
 import com.iheart.playSwagger.generator.SwaggerParameterMapper.mapParam
 import play.api.libs.json.JsValue.jsValueToJsLookup
@@ -339,8 +340,8 @@ final case class SwaggerSpecGenerator(
   private lazy val defaultBase: JsObject =
     readYmlOrJson[JsObject](baseSpecFileName).getOrElse(throw MissingBaseSpecException)
 
-  private lazy val customMappings: CustomMappings = {
-    readYmlOrJson[CustomMappings](customMappingsFileName).getOrElse(Nil)
+  private lazy val customMappings: Seq[CustomTypeMapping] = {
+    readYmlOrJson[Seq[CustomTypeMapping]](customMappingsFileName).getOrElse(Nil)
   }
 
   private def readYmlOrJson[T: Reads](fileName: String): Option[T] = {

--- a/core/src/main/scala/com/iheart/playSwagger/generator/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/generator/SwaggerSpecGenerator.scala
@@ -1,4 +1,4 @@
-package com.iheart.playSwagger
+package com.iheart.playSwagger.generator
 
 import java.io.File
 
@@ -9,7 +9,8 @@ import scala.util.{Failure, Success, Try}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.iheart.playSwagger.Domain._
 import com.iheart.playSwagger.OutputTransformer.SimpleOutputTransformer
-import com.iheart.playSwagger.ResourceReader.read
+import com.iheart.playSwagger._
+import com.iheart.playSwagger.generator.ResourceReader.read
 import com.iheart.playSwagger.generator.SwaggerParameterMapper.mapParam
 import org.yaml.snakeyaml.Yaml
 import play.api.libs.json.JsValue.jsValueToJsLookup

--- a/core/src/main/scala/com/iheart/playSwagger/generator/YAMLParser.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/generator/YAMLParser.scala
@@ -1,0 +1,17 @@
+package com.iheart.playSwagger.generator
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.yaml.snakeyaml.Yaml
+import play.api.libs.json.{Json, Reads}
+
+object YAMLParser {
+
+  def parseYaml[T](document: String)(implicit fjs: Reads[T]): T = {
+    val yaml = new Yaml()
+    val map = yaml.load[T](document)
+    val mapper = new ObjectMapper()
+    val jsonString = mapper.writeValueAsString(map)
+    Json.parse(jsonString).as[T]
+  }
+
+}

--- a/core/src/test/scala/com/iheart/playSwagger/DefinitionGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/DefinitionGeneratorSpec.scala
@@ -2,6 +2,7 @@ package com.iheart.playSwagger
 
 import com.iheart.playSwagger.Domain._
 import com.iheart.playSwagger.domain.CustomTypeMapping
+import com.iheart.playSwagger.domain.parameter.{CustomSwaggerParameter, GenSwaggerParameter}
 import org.specs2.mutable.Specification
 import play.api.libs.json.Json
 
@@ -80,11 +81,16 @@ class DefinitionGeneratorSpec extends Specification {
       result.length === 7
 
       "with correct string property" >> {
-        result.head === GenSwaggerParameter(name = "barStr", `type` = Some("string"))
+        result.head === GenSwaggerParameter(name = "barStr", required = true, `type` = Some("string"))
       }
 
       "with correct int32 property" >> {
-        result(1) === GenSwaggerParameter(name = "barInt", `type` = Some("integer"), format = Some("int32"))
+        result(1) === GenSwaggerParameter(
+          name = "barInt",
+          required = true,
+          `type` = Some("integer"),
+          format = Some("int32")
+        )
       }
 
       "with correct optional long property" >> {
@@ -98,18 +104,35 @@ class DefinitionGeneratorSpec extends Specification {
       }
 
       "with reference type" >> {
-        result(3) === GenSwaggerParameter(name = "reffedFoo", referenceType = Some("com.iheart.playSwagger.ReffedFoo"))
+        result(3) === GenSwaggerParameter(
+          name = "reffedFoo",
+          required = true,
+          referenceType = Some("com.iheart.playSwagger.ReffedFoo")
+        )
       }
 
       "with sequence of reference type" >> {
         val itemsParam =
-          GenSwaggerParameter(name = "seqReffedFoo", referenceType = Some("com.iheart.playSwagger.ReffedFoo"))
-        result(4) === GenSwaggerParameter(name = "seqReffedFoo", `type` = Some("array"), items = Some(itemsParam))
+          GenSwaggerParameter(
+            name = "seqReffedFoo",
+            required = true,
+            referenceType = Some("com.iheart.playSwagger.ReffedFoo")
+          )
+        result(4) === GenSwaggerParameter(
+          name = "seqReffedFoo",
+          required = true,
+          `type` = Some("array"),
+          items = Some(itemsParam)
+        )
       }
 
       "with optional sequence of reference type" >> {
         val itemsParam =
-          GenSwaggerParameter(name = "optionSeqReffedFoo", referenceType = Some("com.iheart.playSwagger.ReffedFoo"))
+          GenSwaggerParameter(
+            name = "optionSeqReffedFoo",
+            required = true,
+            referenceType = Some("com.iheart.playSwagger.ReffedFoo")
+          )
         result(5) === GenSwaggerParameter(
           name = "optionSeqReffedFoo",
           `type` = Some("array"),
@@ -131,11 +154,16 @@ class DefinitionGeneratorSpec extends Specification {
       result.length === 7
 
       "with correct string property" >> {
-        result.head === GenSwaggerParameter(name = "bar_str", `type` = Some("string"))
+        result.head === GenSwaggerParameter(name = "bar_str", required = true, `type` = Some("string"))
       }
 
       "with correct int32 property" >> {
-        result(1) === GenSwaggerParameter(name = "bar_int", `type` = Some("integer"), format = Some("int32"))
+        result(1) === GenSwaggerParameter(
+          name = "bar_int",
+          required = true,
+          `type` = Some("integer"),
+          format = Some("int32")
+        )
       }
 
       "with correct optional long property" >> {
@@ -149,18 +177,35 @@ class DefinitionGeneratorSpec extends Specification {
       }
 
       "with reference type" >> {
-        result(3) === GenSwaggerParameter(name = "reffed_foo", referenceType = Some("com.iheart.playSwagger.ReffedFoo"))
+        result(3) === GenSwaggerParameter(
+          name = "reffed_foo",
+          required = true,
+          referenceType = Some("com.iheart.playSwagger.ReffedFoo")
+        )
       }
 
       "with sequence of reference type" >> {
         val itemsParam =
-          GenSwaggerParameter(name = "seq_reffed_foo", referenceType = Some("com.iheart.playSwagger.ReffedFoo"))
-        result(4) === GenSwaggerParameter(name = "seq_reffed_foo", `type` = Some("array"), items = Some(itemsParam))
+          GenSwaggerParameter(
+            name = "seq_reffed_foo",
+            required = true,
+            referenceType = Some("com.iheart.playSwagger.ReffedFoo")
+          )
+        result(4) === GenSwaggerParameter(
+          name = "seq_reffed_foo",
+          required = true,
+          `type` = Some("array"),
+          items = Some(itemsParam)
+        )
       }
 
       "with optional sequence of reference type" >> {
         val itemsParam =
-          GenSwaggerParameter(name = "option_seq_reffed_foo", referenceType = Some("com.iheart.playSwagger.ReffedFoo"))
+          GenSwaggerParameter(
+            name = "option_seq_reffed_foo",
+            required = true,
+            referenceType = Some("com.iheart.playSwagger.ReffedFoo")
+          )
         result(5) === GenSwaggerParameter(
           name = "option_seq_reffed_foo",
           `type` = Some("array"),
@@ -182,11 +227,16 @@ class DefinitionGeneratorSpec extends Specification {
       result.length === 7
 
       "with correct string property" >> {
-        result.head === GenSwaggerParameter(name = "bar-str", `type` = Some("string"))
+        result.head === GenSwaggerParameter(name = "bar-str", required = true, `type` = Some("string"))
       }
 
       "with correct int32 property" >> {
-        result(1) === GenSwaggerParameter(name = "bar-int", `type` = Some("integer"), format = Some("int32"))
+        result(1) === GenSwaggerParameter(
+          name = "bar-int",
+          required = true,
+          `type` = Some("integer"),
+          format = Some("int32")
+        )
       }
 
       "with correct optional long property" >> {
@@ -200,18 +250,35 @@ class DefinitionGeneratorSpec extends Specification {
       }
 
       "with reference type" >> {
-        result(3) === GenSwaggerParameter(name = "reffed-foo", referenceType = Some("com.iheart.playSwagger.ReffedFoo"))
+        result(3) === GenSwaggerParameter(
+          name = "reffed-foo",
+          required = true,
+          referenceType = Some("com.iheart.playSwagger.ReffedFoo")
+        )
       }
 
       "with sequence of reference type" >> {
         val itemsParam =
-          GenSwaggerParameter(name = "seq-reffed-foo", referenceType = Some("com.iheart.playSwagger.ReffedFoo"))
-        result(4) === GenSwaggerParameter(name = "seq-reffed-foo", `type` = Some("array"), items = Some(itemsParam))
+          GenSwaggerParameter(
+            name = "seq-reffed-foo",
+            required = true,
+            referenceType = Some("com.iheart.playSwagger.ReffedFoo")
+          )
+        result(4) === GenSwaggerParameter(
+          name = "seq-reffed-foo",
+          required = true,
+          `type` = Some("array"),
+          items = Some(itemsParam)
+        )
       }
 
       "with optional sequence of reference type" >> {
         val itemsParam =
-          GenSwaggerParameter(name = "option-seq-reffed-foo", referenceType = Some("com.iheart.playSwagger.ReffedFoo"))
+          GenSwaggerParameter(
+            name = "option-seq-reffed-foo",
+            required = true,
+            referenceType = Some("com.iheart.playSwagger.ReffedFoo")
+          )
         result(5) === GenSwaggerParameter(
           name = "option-seq-reffed-foo",
           `type` = Some("array"),
@@ -469,9 +536,10 @@ class DefinitionGeneratorSpec extends Specification {
       }
 
       "with correct array property" >> {
-        val itemsParam = GenSwaggerParameter(name = "customKey", `type` = Some("string"))
+        val itemsParam = GenSwaggerParameter(name = "customKey", required = true, `type` = Some("string"))
         result.filter(r => r.name == "customKey").seq.head === GenSwaggerParameter(
           name = "customKey",
+          required = true,
           `type` = Some("array"),
           items = Some(itemsParam)
         )
@@ -497,7 +565,11 @@ class DefinitionGeneratorSpec extends Specification {
 
       "with java collection reference type" >> {
         val itemsParamList =
-          GenSwaggerParameter(name = "attributeList", referenceType = Some("com.iheart.playSwagger.Attribute"))
+          GenSwaggerParameter(
+            name = "attributeList",
+            required = true,
+            referenceType = Some("com.iheart.playSwagger.Attribute")
+          )
         result.filter(r => r.name == "attributeList").seq.head === GenSwaggerParameter(
           name = "attributeList",
           `type` = Some("array"),
@@ -507,7 +579,11 @@ class DefinitionGeneratorSpec extends Specification {
         )
 
         val itemsParamSet =
-          GenSwaggerParameter(name = "attributeSet", referenceType = Some("com.iheart.playSwagger.Attribute"))
+          GenSwaggerParameter(
+            name = "attributeSet",
+            required = true,
+            referenceType = Some("com.iheart.playSwagger.Attribute")
+          )
         result.filter(r => r.name == "attributeSet").seq.head === GenSwaggerParameter(
           name = "attributeSet",
           `type` = Some("array"),

--- a/core/src/test/scala/com/iheart/playSwagger/DefinitionGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/DefinitionGeneratorSpec.scala
@@ -1,6 +1,7 @@
 package com.iheart.playSwagger
 
 import com.iheart.playSwagger.Domain._
+import com.iheart.playSwagger.domain.CustomTypeMapping
 import org.specs2.mutable.Specification
 import play.api.libs.json.Json
 

--- a/core/src/test/scala/com/iheart/playSwagger/OutputTransformerSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/OutputTransformerSpec.scala
@@ -3,6 +3,7 @@ package com.iheart.playSwagger
 import scala.util.{Failure, Success}
 
 import com.iheart.playSwagger.OutputTransformer.SimpleOutputTransformer
+import com.iheart.playSwagger.generator.SwaggerSpecGenerator
 import org.specs2.mutable.Specification
 import play.api.libs.json._
 
@@ -129,7 +130,7 @@ class EnvironmentVariablesIntegrationSpec extends Specification {
   "integration" >> {
     "generate api with placeholders in place" >> {
       val envs = Map("LAST_TRACK_DESCRIPTION" -> "Last track", "PLAYED_TRACKS_DESCRIPTION" -> "Add tracks")
-      val json = SwaggerSpecGenerator(
+      val json = generator.SwaggerSpecGenerator(
         NamingStrategy.None,
         PrefixDomainModelQualifier("com.iheart"),
         outputTransformers = MapVariablesTransformer(envs) :: Nil

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
@@ -7,7 +7,7 @@ import play.routes.compiler.Parameter
 
 class SwaggerParameterMapperSpec extends Specification {
   "mapParam" >> {
-    import SwaggerParameterMapper.mapParam
+    import com.iheart.playSwagger.generator.SwaggerParameterMapper.mapParam
     implicit val cl = this.getClass.getClassLoader
 
     "map org.joda.time.DateTime to integer with format epoch" >> {

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
@@ -1,6 +1,7 @@
 package com.iheart.playSwagger
 
 import com.iheart.playSwagger.Domain._
+import com.iheart.playSwagger.domain.CustomTypeMapping
 import org.specs2.mutable.Specification
 import play.api.libs.json.{JsString, Json}
 import play.routes.compiler.Parameter
@@ -21,7 +22,7 @@ class SwaggerParameterMapperSpec extends Specification {
     "override mapping to map DateTime to string with format date-time" >> {
       "single DateTime" >> {
         val specAsParameter = List(Json.obj("type" -> "string", "format" -> "date-time"))
-        val mappings: CustomMappings = List(CustomTypeMapping(
+        val mappings: Seq[CustomTypeMapping] = List(CustomTypeMapping(
           "org.joda.time.DateTime",
           specAsParameter = specAsParameter
         ))
@@ -37,7 +38,7 @@ class SwaggerParameterMapperSpec extends Specification {
 
       "sequence of DateTimes" >> {
         val specAsProperty = Json.obj("type" -> "string", "format" -> "date-time")
-        val mappings: CustomMappings = List(CustomTypeMapping(
+        val mappings: Seq[CustomTypeMapping] = List(CustomTypeMapping(
           "org.joda.time.DateTime",
           specAsProperty = Some(specAsProperty)
         ))
@@ -59,7 +60,7 @@ class SwaggerParameterMapperSpec extends Specification {
 
     "add new custom type mapping" >> {
       val specAsParameter = List(Json.obj("type" -> "string", "format" -> "date-time"))
-      val mappings: CustomMappings = List(CustomTypeMapping(
+      val mappings: Seq[CustomTypeMapping] = List(CustomTypeMapping(
         "java.util.Date",
         specAsParameter = specAsParameter
       ))
@@ -127,7 +128,7 @@ class SwaggerParameterMapperSpec extends Specification {
     "map String to string without override interference" >> {
 
       val specAsParameter = List(Json.obj("type" -> "string", "format" -> "date-time"))
-      val mappings: CustomMappings = List(
+      val mappings: Seq[CustomTypeMapping] = List(
         CustomTypeMapping(
           "java.time.LocalDate",
           specAsParameter = specAsParameter

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
@@ -1,7 +1,6 @@
 package com.iheart.playSwagger
-
-import com.iheart.playSwagger.Domain._
 import com.iheart.playSwagger.domain.CustomTypeMapping
+import com.iheart.playSwagger.domain.parameter.{CustomSwaggerParameter, GenSwaggerParameter}
 import org.specs2.mutable.Specification
 import play.api.libs.json.{JsString, Json}
 import play.routes.compiler.Parameter
@@ -14,6 +13,7 @@ class SwaggerParameterMapperSpec extends Specification {
     "map org.joda.time.DateTime to integer with format epoch" >> {
       mapParam(Parameter("fieldWithDateTime", "org.joda.time.DateTime", None, None)) === GenSwaggerParameter(
         name = "fieldWithDateTime",
+        required = true,
         `type` = Option("integer"),
         format = Option("epoch")
       )
@@ -73,6 +73,7 @@ class SwaggerParameterMapperSpec extends Specification {
     "map Any to any with example value" >> {
       mapParam(Parameter("fieldWithAny", "Any", None, None)) === GenSwaggerParameter(
         name = "fieldWithAny",
+        required = true,
         `type` = Option("any"),
         example = Option(JsString("any JSON value"))
       )
@@ -81,6 +82,7 @@ class SwaggerParameterMapperSpec extends Specification {
     "map java enum to enum constants" >> {
       mapParam(Parameter("javaEnum", "com.iheart.playSwagger.SampleJavaEnum", None, None)) === GenSwaggerParameter(
         name = "javaEnum",
+        required = true,
         `type` = Option("string"),
         enum = Option(Seq("DISABLED", "ACTIVE"))
       )
@@ -91,6 +93,7 @@ class SwaggerParameterMapperSpec extends Specification {
         Parameter("scalaEnum", "com.iheart.playSwagger.SampleScalaEnum.Value", None, None)
       ) === GenSwaggerParameter(
         name = "scalaEnum",
+        required = true,
         `type` = Option("string"),
         enum = Option(Seq("One", "Two"))
       )
@@ -115,10 +118,12 @@ class SwaggerParameterMapperSpec extends Specification {
     "map scala.collection.immutable.Seq[T] to item type" >> {
       mapParam(Parameter("aField", "scala.collection.immutable.Seq[String]", None, None)) === GenSwaggerParameter(
         name = "aField",
+        required = true,
         nullable = None,
         `type` = Some("array"),
         items = Some(GenSwaggerParameter(
           name = "aField",
+          required = true,
           nullable = None,
           `type` = Some("string")
         ))

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -4,6 +4,7 @@ import java.time.LocalDate
 
 import com.iheart.playSwagger.Domain.CustomMappings
 import com.iheart.playSwagger.RefinedTypes.{Age, Albums, SpotifyAccount}
+import com.iheart.playSwagger.generator.SwaggerSpecGenerator
 import org.specs2.mutable.Specification
 import play.api.libs.json._
 

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -2,8 +2,8 @@ package com.iheart.playSwagger
 
 import java.time.LocalDate
 
-import com.iheart.playSwagger.Domain.CustomMappings
 import com.iheart.playSwagger.RefinedTypes.{Age, Albums, SpotifyAccount}
+import com.iheart.playSwagger.domain.CustomTypeMapping
 import com.iheart.playSwagger.generator.SwaggerSpecGenerator
 import org.specs2.mutable.Specification
 import play.api.libs.json._
@@ -88,8 +88,8 @@ class SwaggerSpecGeneratorSpec extends Specification {
 
   "getCfgFile" >> {
     "valid swagger-custom-mappings yml" >> {
-      val result = gen.readCfgFile[CustomMappings]("swagger-custom-mappings.yml")
-      result must beSome[CustomMappings]
+      val result = gen.readCfgFile[Seq[CustomTypeMapping]]("swagger-custom-mappings.yml")
+      result must beSome[Seq[CustomTypeMapping]]
       val mappings = result.get
       mappings.size must be_>(2)
       mappings.head.`type` mustEqual "java\\.time\\.LocalDate"
@@ -99,7 +99,7 @@ class SwaggerSpecGeneratorSpec extends Specification {
     }
 
     "invalid swagger-settings yml" >> {
-      gen.readCfgFile[CustomMappings]("swagger-custom-mappings_invalid.yml") must throwA[JsResultException]
+      gen.readCfgFile[Seq[CustomTypeMapping]]("swagger-custom-mappings_invalid.yml") must throwA[JsResultException]
     }
   }
 

--- a/docs/AlternativeSetup.md
+++ b/docs/AlternativeSetup.md
@@ -16,7 +16,7 @@ Example (compile time DI):
 package controllers.swagger
 
 import play.api.Configuration
-import com.iheart.playSwagger.SwaggerSpecGenerator
+import com.iheart.playSwagger.generator.SwaggerSpecGenerator
 import play.api.libs.json.JsString
 import play.api.mvc._
 


### PR DESCRIPTION
- ドメインモデルを別ファイルに分割
- SwaggerParameterMapper をクラス化
- mapParams 内に定義されていた関数を独立させた
- コメント付与