### PR TITLE
Add support to avoid siblings for $ref - closes #121

### DIFF
--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecRunner.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecRunner.scala
@@ -10,7 +10,7 @@ import play.api.libs.json.{JsValue, Json}
 object SwaggerSpecRunner extends App {
   implicit def cl: ClassLoader = getClass.getClassLoader
 
-  val targetFile :: routesFile :: domainNameSpaceArgs :: outputTransformersArgs :: swaggerV3String :: apiVersion :: swaggerPrettyJson :: swaggerPlayJavaString :: namingStrategy :: operationIdNamingFullyString :: embedScaladocString :: Nil =
+  val targetFile :: routesFile :: domainNameSpaceArgs :: outputTransformersArgs :: swaggerV3String :: apiVersion :: swaggerPrettyJson :: swaggerPlayJavaString :: swaggerNoRefSiblingsString :: namingStrategy :: operationIdNamingFullyString :: embedScaladocString :: Nil =
     args.toList
   private def fileArg = Paths.get(targetFile)
   private def swaggerJson = {
@@ -18,6 +18,7 @@ object SwaggerSpecRunner extends App {
     val swaggerOperationIdNamingFully = java.lang.Boolean.parseBoolean(operationIdNamingFullyString)
     val embedScaladoc = java.lang.Boolean.parseBoolean(embedScaladocString)
     val swaggerPlayJava = java.lang.Boolean.parseBoolean(swaggerPlayJavaString)
+    val swaggerNoRefSiblings = java.lang.Boolean.parseBoolean(swaggerNoRefSiblingsString)
     val domainModelQualifier = PrefixDomainModelQualifier(domainNameSpaceArgs.split(","): _*)
     val transformersStrs: Seq[String] = if (outputTransformersArgs.isEmpty) Seq() else outputTransformersArgs.split(",")
     val transformers = transformersStrs.map { clazz =>
@@ -37,6 +38,7 @@ object SwaggerSpecRunner extends App {
       outputTransformers = transformers,
       swaggerV3 = swaggerV3,
       swaggerPlayJava = swaggerPlayJava,
+      swaggerNoRefSiblings = swaggerNoRefSiblings,
       apiVersion = Some(apiVersion),
       operationIdFully = swaggerOperationIdNamingFully,
       embedScaladoc = embedScaladoc

--- a/core/src/main/scala/com/iheart/playSwagger/generator/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/generator/SwaggerSpecGenerator.scala
@@ -53,12 +53,13 @@ object SwaggerSpecGenerator {
     )
   }
 
-  def apply(swaggerV3: Boolean, operationIdFully: Boolean, embedScaladoc: Boolean, domainNameSpaces: String*)(implicit
+  def apply(swaggerV3: Boolean, swaggerNoRefSiblings: Boolean, operationIdFully: Boolean, embedScaladoc: Boolean, domainNameSpaces: String*)(implicit
   cl: ClassLoader): SwaggerSpecGenerator = {
     SwaggerSpecGenerator(
       namingConvention = NamingConvention.None,
       modelQualifier = PrefixDomainModelQualifier(domainNameSpaces: _*),
       swaggerV3 = swaggerV3,
+      swaggerNoRefSiblings = swaggerNoRefSiblings,
       operationIdFully = operationIdFully,
       embedScaladoc = embedScaladoc
     )
@@ -89,12 +90,13 @@ final case class SwaggerSpecGenerator(
     outputTransformers: Seq[OutputTransformer] = Nil,
     swaggerV3: Boolean = false,
     swaggerPlayJava: Boolean = false,
+    swaggerNoRefSiblings: Boolean = false,
     apiVersion: Option[String] = None,
     operationIdFully: Boolean = false,
     embedScaladoc: Boolean = false
 )(implicit cl: ClassLoader) {
 
-  private val parameterWriter = new SwaggerParameterWriter(swaggerV3)
+  private val parameterWriter = new SwaggerParameterWriter(swaggerV3, swaggerNoRefSiblings)
 
   private def readYmlOrJson[T: Reads](fileName: String): Option[T] = {
     readCfgFile[T](s"$fileName.json") orElse readCfgFile[T](s"$fileName.yml")

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -121,7 +121,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
       (json \ "tags").asOpt[JsObject] must beNone
     }
 
-    lazy val json = SwaggerSpecGenerator(false, false, false, "com.iheart").generate("test.routes").get
+    lazy val json = SwaggerSpecGenerator(false, false, false, embedScaladoc = false, "com.iheart").generate("test.routes").get
     lazy val pathJson = json \ "paths"
     lazy val definitionsJson = json \ "definitions"
     lazy val postBodyJson = (pathJson \ "/post-body" \ "post").as[JsObject]
@@ -536,7 +536,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
     }
 
     "embedded scaladoc strings" >> {
-      lazy val json = SwaggerSpecGenerator(false, false, embedScaladoc = true, "com.iheart").generate("test.routes").get
+      lazy val json = SwaggerSpecGenerator(false, false, false, embedScaladoc = true, "com.iheart").generate("test.routes").get
       lazy val definitionsJson = json \ "definitions"
       lazy val dayOfWeekJson = (definitionsJson \ "com.iheart.playSwagger.DayOfWeek").asOpt[JsObject]
       dayOfWeekJson must beSome[JsObject]
@@ -715,7 +715,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
     }
 
     "fully operation id" >> {
-      lazy val json = SwaggerSpecGenerator(false, true, false, "com.iheart").generate("test.routes").get
+      lazy val json = SwaggerSpecGenerator(false, false, true, embedScaladoc = false, "com.iheart").generate("test.routes").get
       lazy val addTrackJson = (json \ "paths" \ "/api/station/playedTracks" \ "post").as[JsObject]
       (addTrackJson \ "operationId").as[String] ==== "LiveMeta.addPlayedTracks"
     }
@@ -749,8 +749,35 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
     }
   }
 
+  "integration no ref siblings" >> {
+
+    lazy val json = SwaggerSpecGenerator(false, true ,false, embedScaladoc = false, "com.iheart").generate("test.routes").get
+    lazy val definitionsJson = json \ "definitions"
+    lazy val typeParametricWrapperJson =
+      (definitionsJson \ "com.iheart.playSwagger.TypeParametricWrapper[String, com.iheart.playSwagger.EitherRepr[com.iheart.playSwagger.Cat], Seq[com.iheart.playSwagger.EitherRepr[com.iheart.playSwagger.Dog]]]").as[
+        JsObject
+      ]
+    lazy val otherTypeParametricWrapperJson =
+      (definitionsJson \ "com.iheart.playSwagger.TypeParametricWrapper[Option[String], Seq[com.iheart.playSwagger.Cat], Seq[Option[com.iheart.playSwagger.Dog]]]").as[
+        JsObject
+      ]
+    lazy val dogEitherJson =
+      (definitionsJson \ "com.iheart.playSwagger.EitherRepr[com.iheart.playSwagger.Dog]").as[JsObject]
+    lazy val catEitherJson =
+      (definitionsJson \ "com.iheart.playSwagger.EitherRepr[com.iheart.playSwagger.Cat]").as[JsObject]
+
+    "read parametric type wrappers" >> {
+      (typeParametricWrapperJson \ "properties" \ "maybeOtherPayload" \ "allOf" \ 0 \ "$ref").as[String] === "#/definitions/com.iheart.playSwagger.EitherRepr[com.iheart.playSwagger.Cat]"
+
+      (otherTypeParametricWrapperJson \ "properties" \ "seq" \ "items" \ "items" \ "allOf" \ 0 \ "$ref").as[String] === "#/definitions/com.iheart.playSwagger.Dog"
+
+      (dogEitherJson \ "properties" \ "payload" \ "allOf" \ 0 \ "$ref").as[String] === "#/definitions/com.iheart.playSwagger.Dog"
+      (catEitherJson \ "properties" \ "payload" \ "allOf" \ 0 \ "$ref").as[String] === "#/definitions/com.iheart.playSwagger.Cat"
+    }
+  }
+
   "integration v3" >> {
-    lazy val json = SwaggerSpecGenerator(true, false, false, "com.iheart").generate("testV3.routes").get
+    lazy val json = SwaggerSpecGenerator(true, false, false, embedScaladoc = false, "com.iheart").generate("testV3.routes").get
     lazy val componentSchemasJson = json \ "components" \ "schemas"
     lazy val trackJson = (componentSchemasJson \ "com.iheart.playSwagger.Track").as[JsObject]
 

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerKeys.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerKeys.scala
@@ -5,31 +5,78 @@ import java.io.File
 import sbt.{SettingKey, TaskKey}
 
 trait SwaggerKeys {
-  val swagger: TaskKey[File] = TaskKey[File]("swagger", "generates the swagger API documentation")
+  val swagger: TaskKey[File] = TaskKey[File](
+    "swagger",
+    "generates the swagger API documentation"
+  )
+
   val swaggerDomainNameSpaces: SettingKey[Seq[String]] =
-    SettingKey[Seq[String]]("swaggerDomainNameSpaces", "swagger domain namespaces for model classes")
+    SettingKey[Seq[String]](
+      "swaggerDomainNameSpaces",
+      "swagger domain namespaces for model classes"
+    )
+
   val swaggerTarget: SettingKey[File] =
-    SettingKey[File]("swaggerTarget", "the location of the swagger documentation in your packaged app.")
+    SettingKey[File](
+      "swaggerTarget",
+      "the location of the swagger documentation in your packaged app"
+    )
+
   val swaggerFileName: SettingKey[String] =
-    SettingKey[String]("swaggerFileName", "the swagger filename the swagger documentation in your packaged app.")
+    SettingKey[String](
+      "swaggerFileName",
+      "the swagger filename the swagger documentation in your packaged app"
+    )
+
   val swaggerRoutesFile: SettingKey[String] =
-    SettingKey[String]("swaggerRoutesFile", "the root routes file with which play-swagger start to parse")
+    SettingKey[String](
+      "swaggerRoutesFile",
+      "the root routes file with which play-swagger start to parse"
+    )
+
   val swaggerOutputTransformers: SettingKey[Seq[String]] =
-    SettingKey[Seq[String]]("swaggerOutputTransformers", "list of output transformers for processing swagger file")
+    SettingKey[Seq[String]](
+      "swaggerOutputTransformers",
+      "list of output transformers for processing swagger file"
+    )
+
   val swaggerV3: SettingKey[Boolean] =
-    SettingKey[Boolean]("swaggerV3", "whether to to produce output compatible with Swagger 3 (also knwon as OpenAPI 3)")
+    SettingKey[Boolean](
+      "swaggerV3",
+      "whether to produce output compatible with Swagger 3 (also known as OpenAPI 3)"
+    )
+
   val envOutputTransformer = "com.iheart.playSwagger.EnvironmentVariablesTransformer"
 
-  val swaggerAPIVersion: SettingKey[String] = SettingKey[String]("swaggerAPIVersion", "Version of the API")
+  val swaggerAPIVersion: SettingKey[String] =
+    SettingKey[String](
+      "swaggerAPIVersion",
+      "Version of the API"
+    )
 
   val swaggerPrettyJson: SettingKey[Boolean] =
-    SettingKey[Boolean]("swaggerPrettyJson", "True, if needs to pretty print Swagger's documentation")
+    SettingKey[Boolean](
+      "swaggerPrettyJson",
+      "True, if needs to pretty print Swagger's documentation"
+    )
 
   val swaggerPlayJava: SettingKey[Boolean] =
-    SettingKey[Boolean]("swaggerPlayJava", "True, if use play java and use jackson to generate model schema")
+    SettingKey[Boolean](
+      "swaggerPlayJava",
+      "True, if use play java and use jackson to generate model schema"
+    )
+
+  val swaggerNoRefSiblings: SettingKey[Boolean] =
+    SettingKey[Boolean](
+      "swaggerNoRefSiblings",
+      "whether to produce output where a '$ref' has no siblings"
+    )
 
   val swaggerNamingStrategy: SettingKey[String] =
-    SettingKey[String]("swaggerNamingStrategy", "Naming strategy to decode case class fields")
+    SettingKey[String](
+      "swaggerNamingStrategy",
+      "Naming strategy to decode case class fields"
+    )
 
   val swaggerOperationIdNamingFully: SettingKey[Boolean] =
     SettingKey[Boolean](

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
@@ -35,6 +35,7 @@ object SwaggerPlugin extends AutoPlugin {
     swaggerAPIVersion := version.value,
     swaggerPrettyJson := false,
     swaggerPlayJava := false,
+    swaggerNoRefSiblings := true,
     swaggerNamingStrategy := "none",
     swaggerOperationIdNamingFully := false,
     embedScaladoc := false,
@@ -49,6 +50,7 @@ object SwaggerPlugin extends AutoPlugin {
         swaggerAPIVersion.value ::
         swaggerPrettyJson.value.toString ::
         swaggerPlayJava.value.toString ::
+        swaggerNoRefSiblings.value.toString ::
         swaggerNamingStrategy.value ::
         swaggerOperationIdNamingFully.value.toString ::
         embedScaladoc.value.toString ::


### PR DESCRIPTION
This pull request adds a new boolean option `swaggerNoRefSiblings` which defaults to `false`. If this option is set to `true` all referenced objects which have siblings are embedded in an `allOf`.

Example: 

`swaggerNoRefSiblings := false` (default)

```json
          "shippingAddress" : {
            "nullable" : true,
            "$ref" : "#/components/schemas/ShippingAddress"
          },
```

`swaggerNoRefSiblings := true`

```json
          "shippingAddress" : {
            "nullable" : true,
            "allOf" : [ {
              "$ref" : "#/components/schemas/ShippingAddress"
            } ]
          },
```