### PR TITLE
Treat value classes as plain fields with new `anyValsAsUnderlyingType` option

### DIFF
--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecRunner.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecRunner.scala
@@ -10,13 +10,14 @@ import play.api.libs.json.{JsValue, Json}
 object SwaggerSpecRunner extends App {
   implicit def cl: ClassLoader = getClass.getClassLoader
 
-  val targetFile :: routesFile :: domainNameSpaceArgs :: outputTransformersArgs :: swaggerV3String :: apiVersion :: swaggerPrettyJson :: swaggerPlayJavaString :: namingStrategy :: operationIdNamingFullyString :: embedScaladocString :: Nil =
+  val targetFile :: routesFile :: domainNameSpaceArgs :: outputTransformersArgs :: swaggerV3String :: apiVersion :: swaggerPrettyJson :: swaggerPlayJavaString :: namingStrategy :: operationIdNamingFullyString :: embedScaladocString :: anyValsAsUnderlyingTypeString :: Nil =
     args.toList
   private def fileArg = Paths.get(targetFile)
   private def swaggerJson = {
     val swaggerV3 = java.lang.Boolean.parseBoolean(swaggerV3String)
     val swaggerOperationIdNamingFully = java.lang.Boolean.parseBoolean(operationIdNamingFullyString)
     val embedScaladoc = java.lang.Boolean.parseBoolean(embedScaladocString)
+    val anyValsAsUnderlyingType = java.lang.Boolean.parseBoolean(anyValsAsUnderlyingTypeString)
     val swaggerPlayJava = java.lang.Boolean.parseBoolean(swaggerPlayJavaString)
     val domainModelQualifier = PrefixDomainModelQualifier(domainNameSpaceArgs.split(","): _*)
     val transformersStrs: Seq[String] = if (outputTransformersArgs.isEmpty) Seq() else outputTransformersArgs.split(",")
@@ -39,7 +40,8 @@ object SwaggerSpecRunner extends App {
       swaggerPlayJava = swaggerPlayJava,
       apiVersion = Some(apiVersion),
       operationIdFully = swaggerOperationIdNamingFully,
-      embedScaladoc = embedScaladoc
+      embedScaladoc = embedScaladoc,
+      anyValsAsUnderlyingType = anyValsAsUnderlyingType
     ).generate(routesFile).get
 
     if (swaggerPrettyJson.toBoolean) Json.prettyPrint(swaggerSpec)

--- a/core/src/main/scala/com/iheart/playSwagger/generator/DefinitionGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/generator/DefinitionGenerator.scala
@@ -23,7 +23,8 @@ final case class DefinitionGenerator(
     swaggerPlayJava: Boolean = false,
     _mapper: ObjectMapper = new ObjectMapper(),
     namingConvention: NamingConvention = NamingConvention.None,
-    embedScaladoc: Boolean = false
+    embedScaladoc: Boolean = false,
+    anyValsAsUnderlyingType: Boolean = false
 )(implicit cl: ClassLoader) {
 
   private val refinedTypePattern = raw"(eu\.timepit\.refined\.api\.Refined(?:\[.+])?)".r
@@ -120,7 +121,7 @@ final case class DefinitionGenerator(
 
           val rawType = if (isRefinedType(dealiasedType)) {
             field.info.dealias.typeArgs.head
-          } else if (isAnyValType(dealiasedType)) {
+          } else if (anyValsAsUnderlyingType && isAnyValType(dealiasedType)) {
             extractTypeFromAnyVal(dealiasedType)
           } else {
             dealiasedType

--- a/core/src/main/scala/com/iheart/playSwagger/generator/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/generator/SwaggerSpecGenerator.scala
@@ -73,6 +73,14 @@ object SwaggerSpecGenerator {
     )
   }
 
+  def apply(anyValsAsUnderlyingType: Boolean, domainNameSpaces: String*)(implicit
+  cl: ClassLoader): SwaggerSpecGenerator = {
+    SwaggerSpecGenerator(
+      anyValsAsUnderlyingType = anyValsAsUnderlyingType,
+      modelQualifier = PrefixDomainModelQualifier(domainNameSpaces: _*)
+    )
+  }
+
 }
 
 /**
@@ -91,7 +99,8 @@ final case class SwaggerSpecGenerator(
     swaggerPlayJava: Boolean = false,
     apiVersion: Option[String] = None,
     operationIdFully: Boolean = false,
-    embedScaladoc: Boolean = false
+    embedScaladoc: Boolean = false,
+    anyValsAsUnderlyingType: Boolean = false
 )(implicit cl: ClassLoader) {
 
   private val parameterWriter = new SwaggerParameterWriter(swaggerV3)
@@ -109,7 +118,8 @@ final case class SwaggerSpecGenerator(
     mapper = swaggerParameterMapper,
     swaggerPlayJava = swaggerPlayJava,
     namingConvention = namingConvention,
-    embedScaladoc = embedScaladoc
+    embedScaladoc = embedScaladoc,
+    anyValsAsUnderlyingType = anyValsAsUnderlyingType
   )
 
   // routes with their prefix

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -1,14 +1,15 @@
 package com.iheart.playSwagger
 
-import java.time.LocalDate
-
 import com.iheart.playSwagger.RefinedTypes.{Age, Albums, SpotifyAccount}
 import com.iheart.playSwagger.domain.CustomTypeMapping
 import com.iheart.playSwagger.generator.SwaggerSpecGenerator
 import org.specs2.mutable.Specification
 import play.api.libs.json._
 
-case class Track(name: String, genre: Option[String], artist: Artist, related: Seq[Artist], numbers: Seq[Int])
+import java.time.LocalDate
+
+case class Track(name: String, genre: Option[String], artist: Artist, related: Seq[Artist], numbers: Seq[Int], length: Length)
+
 case class Artist(name: String, age: Age, spotifyAccount: SpotifyAccount, albums: Albums)
 
 case class Student(name: String, teacher: Option[Teacher])
@@ -19,6 +20,8 @@ case class Animal(name: String, keeper: Keeper, birthDate: LocalDate, lastChecku
 case class Keeper(internalFieldName1: String, internalFieldName2: Int)
 
 case class Subject(name: String)
+
+case class Length(value: Int) extends AnyVal
 
 /**
   * @param name e.g. Sunday, Monday, TuesDay...
@@ -193,6 +196,10 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
 
     "read definition from referenceTypes" >> {
       (trackJson \ "properties" \ "name" \ "type").as[String] === "string"
+    }
+
+    "read definition from referenceTypes with any val" >> {
+      (trackJson \ "properties" \ "length" \ "type").as[String] === "integer"
     }
 
     "read schema of referenced type" >> {
@@ -615,7 +622,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
     }
 
     "definitions exposes 'required' array if there are required properties" >> {
-      val requiredFields = Seq("name", "artist", "related", "numbers")
+      val requiredFields = Seq("name", "artist", "related", "numbers", "length")
       (trackJson \ "required").as[Seq[String]] must contain(allOf(requiredFields.toSeq: _*).exactly)
     }
 

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerKeys.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerKeys.scala
@@ -42,4 +42,10 @@ trait SwaggerKeys {
       "embedScaladoc",
       "Output schema description using scaladoc of case class"
     )
+
+  val anyValsAsUnderlyingType: SettingKey[Boolean] =
+    SettingKey[Boolean](
+      "anyValsAsUnderlyingType",
+      "Output the type of an AnyVal case class as the type of the underlying primitive"
+    )
 }

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
@@ -38,6 +38,7 @@ object SwaggerPlugin extends AutoPlugin {
     swaggerNamingStrategy := "none",
     swaggerOperationIdNamingFully := false,
     embedScaladoc := false,
+    anyValsAsUnderlyingType := false,
     swagger := Def.task[File] {
       swaggerTarget.value.mkdirs()
       val file = swaggerTarget.value / swaggerFileName.value
@@ -52,6 +53,7 @@ object SwaggerPlugin extends AutoPlugin {
         swaggerNamingStrategy.value ::
         swaggerOperationIdNamingFully.value.toString ::
         embedScaladoc.value.toString ::
+        anyValsAsUnderlyingType.value.toString ::
         Nil
       val swaggerClasspath =
         data((Runtime / fullClasspath).value) ++ update.value.select(configurationFilter(SwaggerConfig.name))


### PR DESCRIPTION
### What this PR does

Adds a new setting key `anyValsAsUnderlyingType` which, when enabled, models a `case class Foo(value: Int) extends AnyVal` as just a field (`"foo": {"type": "integer"}`) instead of an object.
By default this key is set to false to maintain the existing behaviour of the plugin.

### Why this is needed

Scala value classes are often used internally to provide type safety without runtime overhead. However, when exposed via an API, it's more intuitive and expected for them to appear as their underlying type rather than as separate objects.