### PR TITLE
add http verb to fully operation id

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,8 +501,8 @@ responses:
 
 #### Duplicate operationId?
 
-It can be configured in `build.sbt`. 
-This setting allows you to set the `${controllerName}.${methodName}` to name the operationId.
+It can be configured in `build.sbt`.
+This setting allows you to set the `{httpMethodName}.${controllerName}.${methodName}` to name the operationId.
 
 ```sbt
 swaggerOperationIdNamingFully := true

--- a/core/src/main/scala/com/iheart/playSwagger/generator/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/generator/SwaggerSpecGenerator.scala
@@ -419,7 +419,7 @@ final case class SwaggerSpecGenerator(
 
     // コントローラー名とメソッド名、もしくはメソッド名のみから operationId を取得する
     val operationId = Json.obj(
-      "operationId" -> (if (operationIdFully) s"${route.call.controller}.${route.call.method}" else route.call.method)
+      "operationId" -> (if (operationIdFully) s"${route.verb.value.toLowerCase}.${route.call.controller}.${route.call.method}" else route.call.method)
     )
 
     // operationId, tag, parameter object, コメントから生成されたその他の情報をマージする

--- a/core/src/main/scala/com/iheart/playSwagger/generator/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/generator/SwaggerSpecGenerator.scala
@@ -419,7 +419,9 @@ final case class SwaggerSpecGenerator(
 
     // コントローラー名とメソッド名、もしくはメソッド名のみから operationId を取得する
     val operationId = Json.obj(
-      "operationId" -> (if (operationIdFully) s"${route.verb.value.toLowerCase}.${route.call.controller}.${route.call.method}" else route.call.method)
+      "operationId" -> (if (operationIdFully)
+                          s"${route.verb.value.toLowerCase}.${route.call.controller}.${route.call.method}"
+                        else route.call.method)
     )
 
     // operationId, tag, parameter object, コメントから生成されたその他の情報をマージする

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -717,7 +717,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
     "fully operation id" >> {
       lazy val json = SwaggerSpecGenerator(false, true, false, "com.iheart").generate("test.routes").get
       lazy val addTrackJson = (json \ "paths" \ "/api/station/playedTracks" \ "post").as[JsObject]
-      (addTrackJson \ "operationId").as[String] ==== "LiveMeta.addPlayedTracks"
+      (addTrackJson \ "operationId").as[String] ==== "post.LiveMeta.addPlayedTracks"
     }
 
     "should maintain route file order" >> {


### PR DESCRIPTION
Add an HTTP verb to the fully operationId for avoiding error: 
`"Operations must have unique operationIds."`,
when you have the same route in GET/POST/PUT